### PR TITLE
Refactor EasyMicroservices.Serialization project's refrence in other …

### DIFF
--- a/src/CSharp/EasyMicroservices.Serialization.BinaryGo/EasyMicroservices.Serialization.BinaryGo.csproj
+++ b/src/CSharp/EasyMicroservices.Serialization.BinaryGo/EasyMicroservices.Serialization.BinaryGo.csproj
@@ -20,7 +20,6 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <ProjectReference Include="..\EasyMicroservice.Serialization\EasyMicroservices.Serialization.csproj" />
 	  <ProjectReference Include="..\EasyMicroservices.Serialization\EasyMicroservices.Serialization.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/CSharp/EasyMicroservices.Serialization.NewtonSoft.Json/EasyMicroservices.Serialization.Newtonsoft.Json.csproj
+++ b/src/CSharp/EasyMicroservices.Serialization.NewtonSoft.Json/EasyMicroservices.Serialization.Newtonsoft.Json.csproj
@@ -15,7 +15,6 @@
 		<DocumentationFile>.\bin\$(Configuration)\$(TargetFramework)\EasyMicroservice.Serialization.Newtonsoft.Json.xml</DocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\EasyMicroservice.Serialization\EasyMicroservices.Serialization.csproj" />
 		<ProjectReference Include="..\EasyMicroservices.Serialization\EasyMicroservices.Serialization.csproj" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 	</ItemGroup>

--- a/src/CSharp/EasyMicroservices.Serialization.System.Text.Json/EasyMicroservices.Serialization.System.Text.Json.csproj
+++ b/src/CSharp/EasyMicroservices.Serialization.System.Text.Json/EasyMicroservices.Serialization.System.Text.Json.csproj
@@ -15,7 +15,6 @@
 		<DocumentationFile>.\bin\$(Configuration)\$(TargetFramework)\EasyMicroservice.Serialization.System.Text.json.xml</DocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\EasyMicroservice.Serialization\EasyMicroservices.Serialization.csproj" />
 		<ProjectReference Include="..\EasyMicroservices.Serialization\EasyMicroservices.Serialization.csproj" />
 	</ItemGroup>
  <ItemGroup>  

--- a/src/CSharp/EasyMicroservices.Serialization.Tests/EasyMicroservices.Serialization.Tests.csproj
+++ b/src/CSharp/EasyMicroservices.Serialization.Tests/EasyMicroservices.Serialization.Tests.csproj
@@ -25,10 +25,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\EasyMicroservice.Serialization.BinaryGo\EasyMicroservices.Serialization.BinaryGo.csproj" />
-	  <ProjectReference Include="..\EasyMicroservice.Serialization.NewtonSoft.Json\EasyMicroservices.Serialization.Newtonsoft.Json.csproj" />
-	  <ProjectReference Include="..\EasyMicroservice.Serialization.System.Text.Json\EasyMicroservices.Serialization.System.Text.Json.csproj" />
-	  <ProjectReference Include="..\EasyMicroservice.Serialization\EasyMicroservices.Serialization.csproj" />
+	  <ProjectReference Include="..\EasyMicroservices.Serialization.BinaryGo\EasyMicroservices.Serialization.BinaryGo.csproj" />
+	  <ProjectReference Include="..\EasyMicroservices.Serialization.NewtonSoft.Json\EasyMicroservices.Serialization.Newtonsoft.Json.csproj" />
+	  <ProjectReference Include="..\EasyMicroservices.Serialization.System.Text.Json\EasyMicroservices.Serialization.System.Text.Json.csproj" />
+	  <ProjectReference Include="..\EasyMicroservices.Serialization\EasyMicroservices.Serialization.csproj" />
 	  <ProjectReference Include="..\EasyMicroservices.Serialization\EasyMicroservices.Serialization.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
project EasyMicroservices.Serialization name changed from "EasyMicroservice.Serialization" to "EasyMicroservices.Serialization" but it's references in other projects didn't refactored properly that prevents solution from building with this error:
"Unable to find project ..\EasyMicroservice.Serialization\EasyMicroservices.Serialization.csproj check that the project refrence is valid and the the project file exists."