### PR TITLE
ci: setup and automate semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on: [workflow_dispatch]
+
+jobs:
+  build-test-prep-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version:  |
+            3.1.x
+            5.0.x
+            6.0.x
+
+        env:
+          DOTNET_INSTALL_DIR: /usr/share/dotnet
+      - name: build and test
+        run: |
+          dotnet restore ./src/CSharp/EasyMicroservices.Serialization.sln
+          dotnet build ./src/CSharp/EasyMicroservices.Serialization.sln --no-restore
+          dotnet test ./src/CSharp/EasyMicroservices.Serialization.sln --no-build
+      - name: setup semantic-release
+        run: |
+          npm install -D semantic-release
+          npm install -D @semantic-release/git
+          npm install -D @semantic-release/changelog
+          npm install -D @semantic-release/exec
+          npm install -D semantic-release-dotnet
+          npm install -D conventional-changelog-conventionalcommits
+      - name: run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,40 @@
+{
+    "branches": [
+        "develop"
+    ],
+    "plugins": [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "preset": "conventionalcommits"
+            }
+        ],
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "preset": "conventionalcommits"
+            }
+        ],
+        "@semantic-release/github",
+        "@semantic-release/changelog",
+        [
+            "semantic-release-dotnet",
+            {
+                "paths": [
+                    "Directory.Build.props"
+                ],
+            }
+        ],
+        [
+            "@semantic-release/git",
+            {
+                "assets": [
+                    "Directory.Build.props",
+                    "*.md",
+                    "docs"
+                ],
+                "message": "chore: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+            }
+        ]
+    ]
+}


### PR DESCRIPTION
automate github Release
automate package versioning
auto generate change log 
auto generate release-notes

https://github.com/semantic-release/semantic-release

all its needed use [Angular Commit Message Conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format)

e.g. "feat: add central configuration"

Every release run added action(`Release`) to generate release-notes