### PR TITLE
Init project in golang, implement string serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,27 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+## For golang
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Idea dirs
+.idea/
+.vscode/

--- a/src/Golang/encodingjson/lib.go
+++ b/src/Golang/encodingjson/lib.go
@@ -1,0 +1,19 @@
+package encodingjson
+
+import "encoding/json"
+
+type JsonSerializer struct {
+}
+
+func (j JsonSerializer) Serialize(value any) (string, error) {
+	res, err := json.Marshal(value)
+
+	if err != nil {
+		return "", err
+	}
+	return string(res), nil
+}
+
+func (j JsonSerializer) Deserialize(s string, v any) error {
+	return json.Unmarshal([]byte(s), v)
+}

--- a/src/Golang/encodingjson/lib.go
+++ b/src/Golang/encodingjson/lib.go
@@ -2,9 +2,11 @@ package encodingjson
 
 import "encoding/json"
 
+// JsonSerializer is a string serializer which uses encoding/json package.
 type JsonSerializer struct {
 }
 
+// Serialize is implementation of serialize method from StringSerializer interface.
 func (j JsonSerializer) Serialize(value any) (string, error) {
 	res, err := json.Marshal(value)
 
@@ -14,6 +16,7 @@ func (j JsonSerializer) Serialize(value any) (string, error) {
 	return string(res), nil
 }
 
+// Deserialize is implementation of deserialize method from StringSerializer interface.
 func (j JsonSerializer) Deserialize(s string, v any) error {
 	return json.Unmarshal([]byte(s), v)
 }

--- a/src/Golang/encodingjson/lib_test.go
+++ b/src/Golang/encodingjson/lib_test.go
@@ -1,0 +1,46 @@
+package encodingjson_test
+
+import (
+	serialization "github.com/EasyMicroservices/Serialization"
+	"github.com/EasyMicroservices/Serialization/encodingjson"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type TestStruct struct {
+	Int     int     `json:"int"`
+	Float   float32 `json:"float"`
+	Str     string  `json:"str"`
+	Boolean bool    `json:"boolean"`
+	Array   []int   `json:"array"`
+}
+
+func TestStrSerializeWithEncodingJson(t *testing.T) {
+	ts := TestStruct{
+		Int:     1,
+		Float:   3.2,
+		Str:     "test str",
+		Boolean: false,
+		Array:   []int{1, 2, 3},
+	}
+	expectedJson := "{\"int\":1,\"float\":3.2,\"str\":\"test str\",\"boolean\":false,\"array\":[1,2,3]}"
+
+	serialized, err := serialization.StrSerialize[TestStruct](ts, new(encodingjson.JsonSerializer))
+	assert.Nil(t, err)
+	assert.Equal(t, expectedJson, serialized)
+}
+
+func TestStrDeserializeWithEncodingJson(t *testing.T) {
+	jsonStr := "{\"int\":1,\"float\":3.2,\"str\":\"test str\",\"boolean\":false,\"array\":[1,2,3]}"
+	expectedValue := TestStruct{
+		Int:     1,
+		Float:   3.2,
+		Str:     "test str",
+		Boolean: false,
+		Array:   []int{1, 2, 3},
+	}
+
+	deserialized, err := serialization.StrDeserialize[TestStruct](jsonStr, new(encodingjson.JsonSerializer))
+	assert.Nil(t, err)
+	assert.Equal(t, expectedValue, deserialized)
+}

--- a/src/Golang/go.mod
+++ b/src/Golang/go.mod
@@ -1,3 +1,11 @@
 module github.com/EasyMicroservices/Serialization
 
 go 1.19
+
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/src/Golang/go.mod
+++ b/src/Golang/go.mod
@@ -1,0 +1,3 @@
+module github.com/EasyMicroservices/Serialization
+
+go 1.19

--- a/src/Golang/go.sum
+++ b/src/Golang/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/Golang/lib.go
+++ b/src/Golang/lib.go
@@ -1,18 +1,22 @@
 package serialization
 
+// Serializer is base interface for all serializers.
 type Serializer interface {
 }
 
+// StringSerializer is an interface that all string serializers should implement it.
 type StringSerializer interface {
 	Serializer
 	Serialize(value any) (string, error)
 	Deserialize(s string, v any) error
 }
 
+// StrSerialize serializes value to string using given serializer.
 func StrSerialize[T any](value T, serializer StringSerializer) (string, error) {
 	return serializer.Serialize(value)
 }
 
+// StrDeserialize deserializes string to given type using serializer.
 func StrDeserialize[T any](s string, serializer StringSerializer) (T, error) {
 	v := new(T)
 	err := serializer.Deserialize(s, v)

--- a/src/Golang/lib.go
+++ b/src/Golang/lib.go
@@ -1,0 +1,20 @@
+package serialization
+
+type Serializer interface {
+}
+
+type StringSerializer interface {
+	Serializer
+	Serialize(value any) (string, error)
+	Deserialize(s string, v any) error
+}
+
+func StrSerialize[T any](value T, serializer StringSerializer) (string, error) {
+	return serializer.Serialize(value)
+}
+
+func StrDeserialize[T any](s string, serializer StringSerializer) (T, error) {
+	v := new(T)
+	err := serializer.Deserialize(s, v)
+	return *v, err
+}


### PR DESCRIPTION
- Init golang serializer project.
- Add `Serializer` and `StringSerializer` interfaces.
- Implement `StrSerialize` and `StrDeserialize` functions.
- Implement `JsonSerializer` struct using `encoding/json` package.
- Implement unit tests.
- Add comments.
- Update .gitignore for golang.