### PR TITLE
fix: use windows on NuGet Push Public

### DIFF
--- a/.github/workflows/nuget-push-public.yml
+++ b/.github/workflows/nuget-push-public.yml
@@ -4,10 +4,10 @@ on: [workflow_dispatch]
 
 jobs:
   build-test-prep-push:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             3.1.x
@@ -16,8 +16,14 @@ jobs:
 
         env:
           DOTNET_INSTALL_DIR: /usr/share/dotnet
+      - name: Restore dependencies
+        run: dotnet restore ./src/CSharp/EasyMicroservices.Serialization.sln
+      - name: Build
+        run: dotnet build ./src/CSharp/EasyMicroservices.Serialization.sln --no-restore
+      - name: Test
+        run: dotnet test ./src/CSharp/EasyMicroservices.Serialization.sln --no-build --verbosity normal
       - name: Create the package
-        run: dotnet test ./src/CSharp/EasyMicroservices.Serialization.sln && dotnet pack ./src/CSharp/EasyMicroservices.Serialization.sln -c Release --output nupkgs
+        run: dotnet pack ./src/CSharp/EasyMicroservices.Serialization.sln --output nupkgs
       - name: Publish the package to NuGet.org
         env:
           NUGET_KEY: ${{secrets.NUGET_KEY}}


### PR DESCRIPTION
.net framework need to run on windows on "NuGet Push Public" action

its need nuget key with name of "NUGET_KEY" on environment variables